### PR TITLE
Add provenance tracking to UKS relationships

### DIFF
--- a/BrainSimulator.sln
+++ b/BrainSimulator.sln
@@ -13,6 +13,8 @@ Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "PythonProj", "PythonProj\Py
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BrainSimMAC", "BrainSimMAC\BrainSimMAC.csproj", "{56FEB147-FC89-4712-939B-A6C08D5B2126}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UKS.Tests", "UKS.Tests\UKS.Tests.csproj", "{74FE49C0-BF80-44A5-A527-104145358362}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,18 @@ Global
 		{56FEB147-FC89-4712-939B-A6C08D5B2126}.Release|x64.Build.0 = Release|Any CPU
 		{56FEB147-FC89-4712-939B-A6C08D5B2126}.Release|x86.ActiveCfg = Release|Any CPU
 		{56FEB147-FC89-4712-939B-A6C08D5B2126}.Release|x86.Build.0 = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|x64.Build.0 = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Debug|x86.Build.0 = Debug|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|x64.ActiveCfg = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|x64.Build.0 = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|x86.ActiveCfg = Release|Any CPU
+		{74FE49C0-BF80-44A5-A527-104145358362}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UKS.Tests/ProvenanceTests.cs
+++ b/UKS.Tests/ProvenanceTests.cs
@@ -1,0 +1,48 @@
+using System;
+using UKS;
+using Xunit;
+
+namespace UKS.Tests;
+
+public class ProvenanceTests
+{
+    [Fact]
+    public void AddStatement_StoresProvenanceOnRelationship()
+    {
+        var uks = new UKS.UKS(true);
+
+        Relationship relationship = uks.AddStatement("Fido", "is-a", "dog", provenance: "Bill");
+
+        Assert.NotNull(relationship);
+        Assert.Contains(relationship.Provenance, t => string.Equals(t.Label, "Bill", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AddStatement_AddsAdditionalProvenanceForExistingRelationship()
+    {
+        var uks = new UKS.UKS(true);
+
+        Relationship initial = uks.AddStatement("Fido", "is-a", "dog", provenance: "Bill");
+        Relationship same = uks.AddStatement("Fido", "is-a", "dog", provenance: "Mary");
+
+        Assert.Same(initial, same);
+        Assert.Equal(2, initial.Provenance.Count);
+        Assert.Contains(initial.Provenance, t => string.Equals(t.Label, "Bill", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(initial.Provenance, t => string.Equals(t.Label, "Mary", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AddStatement_DifferentStatementKeepsIndependentProvenance()
+    {
+        var uks = new UKS.UKS(true);
+
+        Relationship dog = uks.AddStatement("Fido", "is-a", "dog", provenance: "Bill");
+        Relationship cat = uks.AddStatement("Fido", "is-a", "cat", provenance: "Mary");
+
+        Assert.Single(dog.Provenance);
+        Assert.Single(cat.Provenance);
+        Assert.Contains(dog.Provenance, t => string.Equals(t.Label, "Bill", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(cat.Provenance, t => string.Equals(t.Label, "Mary", StringComparison.OrdinalIgnoreCase));
+    }
+}
+

--- a/UKS.Tests/UKS.Tests.csproj
+++ b/UKS.Tests/UKS.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UKS\UKS.csproj" />
+  </ItemGroup>
+</Project>

--- a/UKS/Relationship.cs
+++ b/UKS/Relationship.cs
@@ -133,6 +133,14 @@ public class Relationship
     /// </summary>
     public List<Relationship> clausesFrom = new();
 
+    private readonly List<Thing> provenance = new();
+    /// <summary>
+    /// Things that represent the provenance (sources) of this relationship.
+    /// </summary>
+    public IReadOnlyList<Thing> Provenance => provenance.AsReadOnly();
+
+    internal List<Thing> ProvenanceWriteable => provenance;
+
     private float weight = 1;
     public float Weight
     {
@@ -218,6 +226,7 @@ public class Relationship
         else Clauses = new(r.Clauses);
         if (r.clausesFrom == null) clausesFrom = new();
         else clausesFrom = new(r.clausesFrom);
+        provenance.AddRange(r.ProvenanceWriteable);
     }
 
     public void ClearHits()
@@ -251,6 +260,22 @@ public class Relationship
         }
 
         return this;
+    }
+
+    public void AddProvenance(Thing? provenanceSource)
+    {
+        if (provenanceSource == null) return;
+        if (!provenance.Contains(provenanceSource))
+            provenance.Add(provenanceSource);
+    }
+
+    public void AddProvenance(IEnumerable<Thing>? provenanceSources)
+    {
+        if (provenanceSources == null) return;
+        foreach (Thing source in provenanceSources)
+        {
+            AddProvenance(source);
+        }
     }
 
     public string ToString(List<Relationship> stack)
@@ -394,4 +419,6 @@ public class SRelationship
     public int count = -1;
     public bool GPTVerified = false;
     public List<SClauseType>? clauses = new();
+    public List<int>? provenance = new();
 }
+

--- a/UKS/Thing.cs
+++ b/UKS/Thing.cs
@@ -319,7 +319,7 @@ public partial class Thing
     /// <param name="target">Target Thing</param>
     /// <param name="relationshipType">RelatinoshipType Thing</param>
     /// <returns>the new or existing Relationship</returns>
-    public Relationship AddRelationship(Thing target, Thing relationshipType,bool isStatement = true)
+    public Relationship AddRelationship(Thing target, Thing relationshipType,bool isStatement = true, IEnumerable<Thing>? provenance = null)
     {
         if (relationshipType == null)  //NULL relationship types could be allowed in search Thingys Parameter?
         {
@@ -331,6 +331,7 @@ public partial class Thing
         if (r != null)
         {
             //AdjustRelationship(r.T);
+            r.AddProvenance(provenance);
             return r;
         }
         r = new Relationship()
@@ -369,6 +370,7 @@ public partial class Thing
                         relationshipType.RelationshipsAsTypeWriteable.Add(r);
                 }
         }
+        r.AddProvenance(provenance);
         return r;
     }
 

--- a/UKS/UKS.File.cs
+++ b/UKS/UKS.File.cs
@@ -183,6 +183,22 @@ public partial class UKS
             }
         }
 
+        List<int>? provenance = null;
+        if (l.ProvenanceWriteable.Count > 0)
+        {
+            provenance = new List<int>(l.ProvenanceWriteable.Count);
+            foreach (Thing source in l.ProvenanceWriteable)
+            {
+                int index = UKSList.FindIndex(x => x == source);
+                if (index >= 0)
+                {
+                    provenance.Add(index);
+                }
+            }
+            if (provenance.Count == 0)
+                provenance = null;
+        }
+
         SRelationship sR = new SRelationship()
         {
             source = UKSList.FindIndex(x => x == l.source),
@@ -194,6 +210,7 @@ public partial class UKS
             count = l.count,
             GPTVerified = l.GPTVerified,
             clauses = clauseList,
+            provenance = provenance,
         };
         return sR;
     }
@@ -322,6 +339,16 @@ public partial class UKS
                 Clause ct = new Clause(UKSList[sc.clauseType], UnConvertRelationship(sc.r, stack));
                 if (ct.clause != null)
                     r.Clauses.Add(ct);
+            }
+        }
+        if (p.provenance != null)
+        {
+            foreach (int idx in p.provenance)
+            {
+                if (idx >= 0 && idx < UKSList.Count)
+                {
+                    r.AddProvenance(UKSList[idx]);
+                }
             }
         }
         return r;


### PR DESCRIPTION
## Summary
- add provenance tracking to `Relationship` so statements can record their sources
- extend `AddStatement`/`AddRelationship` and serialization routines to persist provenance metadata
- introduce a new UKS test project with provenance-focused unit tests and hook it into the solution

## Testing
- dotnet test UKS.Tests/UKS.Tests.csproj *(fails: dotnet command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68deac2d2b2c8326a91e6a233c3fb5a8